### PR TITLE
[FIX] 선물 타입이 변경되지 않는 문제

### DIFF
--- a/app/src/main/java/com/w36495/senty/di/NetworkModule.kt
+++ b/app/src/main/java/com/w36495/senty/di/NetworkModule.kt
@@ -39,6 +39,7 @@ object NetworkModule {
     private val jsonOptions = Json {
         ignoreUnknownKeys = true
         coerceInputValues = true
+        encodeDefaults = true
     }
 
     @Provides


### PR DESCRIPTION
## ISSUE
- #28 

## 원인
``` kotlin
@Serializable
data class GiftEntity(
    val type: Int = 0,
    val categoryId: String = "",
    val categoryName: String = "",
    val friendId: String = "",
    val friendName: String = "",
    val date: String = "",
    val mood: String = "",
    val memo: String = "",
    val hasImages: Boolean = false,
    val thumbnail: String? = null,
    val images: List<String> = emptyList(),
    val createdAt: Long = 0L,
    val updatedAt: Long = 0L,
)
```
위와 같이 type에 Int형으로 기본값을 주었다. (0 : 받은 선물, 1 : 준 선물)
그런데 준 선물(1) -> 받은 선물(0)로 변경을 하려니 **기본 값인 0과 같기에 직렬화 과정에서 제외**되었음을 알았다.
[Kotlin-Serialization-EncodeDefault](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-encode-default/)

## 해결
Retrofit의 Converter 설정에 직렬화할 때 기본값도 포함되도록 `encodeDefaults=true` 설정
``` kotlin
private val jsonOptions = Json {
    ignoreUnknownKeys = true
    coerceInputValues = true
    // 추가 !
    encodeDefaults = true
}
```

## ScreenShot
|`수정 전`|`수정 후`|
|:--:|:--:|
|![수정_전](https://github.com/user-attachments/assets/fdd6284f-f1fb-4f11-8a3a-480a66a92477)|![수정_후](https://github.com/user-attachments/assets/d3a24c47-13e4-4714-92b3-760624d0e001)|
|수정이 완료되어도 상단에 `준 선물`로 보임|수정이 완료된 후, 상단이 `받은 선물`로 변경됨|


