### PR TITLE
[FEAT] 친구 정보 동기화 여부를 관리하는 flag 구현 

### DIFF
--- a/app/src/main/java/com/w36495/senty/data/local/datastore/FriendSyncFlagDataStore.kt
+++ b/app/src/main/java/com/w36495/senty/data/local/datastore/FriendSyncFlagDataStore.kt
@@ -1,0 +1,36 @@
+package com.w36495.senty.data.local.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import com.w36495.senty.domain.local.datastore.DataStoreContact
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class FriendSyncFlagDataStore @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) : DataStoreContact<Boolean> {
+    companion object {
+        private val KEY_FRIEND_SYNC_FLAG = booleanPreferencesKey("key_friend_sync_flag")
+    }
+
+    override suspend fun save(value: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_FRIEND_SYNC_FLAG] = value
+        }
+    }
+
+    override suspend fun load(): Boolean? {
+        return dataStore.data
+            .map { it[KEY_FRIEND_SYNC_FLAG] }
+            .firstOrNull()
+    }
+
+    override suspend fun clear() {
+        dataStore.edit { prefs ->
+            prefs.remove(KEY_FRIEND_SYNC_FLAG)
+        }
+    }
+}

--- a/app/src/main/java/com/w36495/senty/data/local/datastore/di/DataStoreModule.kt
+++ b/app/src/main/java/com/w36495/senty/data/local/datastore/di/DataStoreModule.kt
@@ -1,0 +1,37 @@
+package com.w36495.senty.data.local.datastore.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import com.w36495.senty.domain.local.datastore.DataStoreContact
+import com.w36495.senty.data.local.datastore.FriendSyncFlagDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+    @Provides
+    @Singleton
+    fun providePreferencesDataStore(
+        @ApplicationContext context: Context
+    ): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create {
+            context.preferencesDataStoreFile("91ft_dataStore_pref")
+        }
+    }
+
+    @Provides
+    @Singleton
+    fun provideFriendSyncFlagDataStore(
+        dataStore: DataStore<Preferences>
+    ): DataStoreContact<Boolean> {
+        return FriendSyncFlagDataStore(dataStore)
+    }
+}

--- a/app/src/main/java/com/w36495/senty/domain/local/datastore/DataStoreContact.kt
+++ b/app/src/main/java/com/w36495/senty/domain/local/datastore/DataStoreContact.kt
@@ -1,0 +1,9 @@
+package com.w36495.senty.domain.local.datastore
+
+interface DataStoreContact<T> {
+    suspend fun save(value: T)
+
+    suspend fun load(): T?
+
+    suspend fun clear()
+}

--- a/app/src/main/java/com/w36495/senty/domain/usecase/UpdateGiftUseCase.kt
+++ b/app/src/main/java/com/w36495/senty/domain/usecase/UpdateGiftUseCase.kt
@@ -3,6 +3,7 @@ package com.w36495.senty.domain.usecase
 import android.util.Log
 import com.w36495.senty.data.domain.GiftType
 import com.w36495.senty.domain.entity.Gift
+import com.w36495.senty.domain.local.datastore.DataStoreContact
 import com.w36495.senty.domain.repository.FriendRepository
 import com.w36495.senty.domain.repository.GiftRepository
 import javax.inject.Inject
@@ -11,6 +12,7 @@ class UpdateGiftUseCase @Inject constructor(
     private val giftRepository: GiftRepository,
     private val friendRepository: FriendRepository,
     private val updateFriendUseCase: UpdateFriendUseCase,
+    private val friendSyncFlagDataStore: DataStoreContact<Boolean>,
 ) {
     suspend operator fun invoke(gift: Gift): Result<Unit> {
         val beforeGift = giftRepository.getGift(gift.id).getOrThrow()
@@ -22,15 +24,24 @@ class UpdateGiftUseCase @Inject constructor(
                 if (isDifferentGiftType) {
                     val friend = friendRepository.getFriend(gift.friendId).getOrThrow()
 
+                    val receivedCount = if (gift.type == GiftType.RECEIVED) friend.received + 1 else friend.received - 1
+                    val sentCount = if (gift.type == GiftType.SENT) friend.sent + 1 else friend.sent - 1
+
+                    if (receivedCount < 0 || sentCount < 0) {
+                        friendSyncFlagDataStore.save(true)
+                        return Result.failure(Exception("친구 정보 업데이트 실패"))
+                    }
+
                     updateFriendUseCase(
                         friend.copy(
-                             received = if (gift.type == GiftType.RECEIVED) friend.received + 1 else friend.received - 1,
-                            sent = if (gift.type == GiftType.SENT) friend.sent + 1 else friend.sent - 1,
+                            received = receivedCount,
+                            sent = sentCount,
                         )
                     )
                         .onFailure {
                             Log.d("UpdateGiftUseCase", "친구 정보 업데이트 실패")
-                            Result.failure<Unit>(it)
+                            friendSyncFlagDataStore.save(true)
+                            return Result.failure(it)
                         }
                 }
             }

--- a/app/src/test/java/com/w36495/senty/datastore/FakeFriendSyncFlagDataStore.kt
+++ b/app/src/test/java/com/w36495/senty/datastore/FakeFriendSyncFlagDataStore.kt
@@ -1,0 +1,19 @@
+package com.w36495.senty.datastore
+
+import com.w36495.senty.domain.local.datastore.DataStoreContact
+
+class FakeFriendSyncFlagDataStore : DataStoreContact<Boolean> {
+    private var flag: Boolean? = null
+
+    override suspend fun save(value: Boolean) {
+        flag = value
+    }
+
+    override suspend fun load(): Boolean? {
+        return flag
+    }
+
+    override suspend fun clear() {
+        flag = null
+    }
+}

--- a/app/src/test/java/com/w36495/senty/usecase/UpdateGiftUseCaseTest.kt
+++ b/app/src/test/java/com/w36495/senty/usecase/UpdateGiftUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.w36495.senty.usecase
 
 import com.w36495.senty.data.domain.GiftType
 import com.w36495.senty.data.mapper.toDomain
+import com.w36495.senty.datastore.FakeFriendSyncFlagDataStore
 import com.w36495.senty.domain.usecase.UpdateFriendUseCase
 import com.w36495.senty.domain.usecase.UpdateGiftUseCase
 import com.w36495.senty.repository.FakeFriendRepository
@@ -17,9 +18,10 @@ import org.junit.Test
 class UpdateGiftUseCaseTest {
     private val giftRepository = FakeGiftRepository()
     private val friendRepository = FakeFriendRepository()
+    private val friendSyncFlagDataStore = FakeFriendSyncFlagDataStore()
 
     private val updateFriendUseCase = UpdateFriendUseCase(friendRepository)
-    private val useCase = UpdateGiftUseCase(giftRepository, friendRepository, updateFriendUseCase)
+    private val useCase = UpdateGiftUseCase(giftRepository, friendRepository, updateFriendUseCase, friendSyncFlagDataStore)
 
     @Before
     fun setUp() {
@@ -70,8 +72,47 @@ class UpdateGiftUseCaseTest {
         assertEquals(0, afterFriend.sent)
     }
 
+    @Test
+    fun `선물 정보를 수정한 후, 친구 정보가 업데이트 되었을 때 친구 정보 동기화 flag는 null 이다`() = runTest {
+        giftRepository.insertGift(sentGift.toDomain())
+        friendRepository.patchFriend(friend.copy(sent = friend.sent+1).toDomain())
+
+        // 현재 친구 정보 동기화 flag 확인
+        val beforeSyncFlag = friendSyncFlagDataStore.load()
+
+        assertEquals(null, beforeSyncFlag)
+
+        // When : 친구 정보가 업데이트 되었을 때
+        useCase(sentGift.copy(type = GiftType.RECEIVED).toDomain())
+
+        // Then : 친구 정보 동기화 flag는 null이다
+        val afterSyncFlag = friendSyncFlagDataStore.load()
+
+        assertEquals(null, afterSyncFlag)
+    }
+
+    @Test
+    fun `선물 정보를 수정한 후, 친구 정보가 업데이트 되지 못했을 때 친구 정보 동기화 flag 는 true 이다`() = runTest {
+        giftRepository.insertGift(sentGift.copy(friendId = fakeFriend.id).toDomain())
+        friendRepository.patchFriend(fakeFriend.toDomain())
+
+        // 현재 친구 정보 동기화 flag 확인
+        val beforeSyncFlag = friendSyncFlagDataStore.load()
+
+        assertEquals(null, beforeSyncFlag)
+
+        // When : 친구 정보가 업데이트 되지 못했을 때
+        useCase(sentGift.copy(type = GiftType.RECEIVED).toDomain())
+
+        // Then : 친구 정보 동기화 flag 는 true 이다
+        val afterSyncFlag = friendSyncFlagDataStore.load()
+
+        assertEquals(true, afterSyncFlag)
+    }
+
     companion object {
         private val friend = FriendUiModel(id = "1", name = "Friend 1")
+        private val fakeFriend = FriendUiModel(id = "2", name = "Fake Friend")
         private val receivedGift = GiftUiModel(id = "9", type = GiftType.RECEIVED, friendId = friend.id, friendName = friend.name)
         private val sentGift = GiftUiModel(id = "8", type = GiftType.SENT, friendId = friend.id, friendName = friend.name)
     }


### PR DESCRIPTION
## ISSUE
- #28 

## 구현하게 된 이유
- 요구사항
  - 선물의 타입을 수정하면, 친구 정보의 각각의 선물 타입의 개수도 함께 변경되어야 한다.
    ex) 받은 선물 -> 준 선물로 변경하면, 친구 정보에서 받은 선물 -1 준 선물 +1이 되어야 한다.

> 선물 타입은 정상적으로 수정이 되었는데, 만약 친구 정보가 정상적으로 수정되지 않았다면? 어떻게 처리해야할까?

**1. 정상적으로 선물 수정이 완료되었으나, 친구 정보 업데이트가 실패했다는 다이얼로그 표시**
-> 사용자에게 문제를 사전에 알려주어 잘못된 데이터가 보여도 인지가 가능할 것이다.
그러나 이 문제가 **사용자가 꼭 알아야 될 오류일까?** 를 생각해보았을 때 사용자에게 알려주지 않고도 처리가 가능할 것 같았다.
그리고 그럼 언제 잘못된 데이터를 바로 잡아야할까?
사용자로부터 '제 데이터가 잘못되었으니 확인해주세요~'라고 일일이 받을 수는 없을 노릇이다.
친구 목록에 들어갔을 때 업데이트 쳐주는 것이 좋을까? 그럼 굳이 다이얼로그를 보여주지 않아도 되지 않을까?

**2. 오류가 발생했을 때 DataStore에 flag 값을 넣어놓고 친구 목록에 진입했을 때 flag값을 확인하여 정보 업데이트**
DataStore의 flag 값을 확인하면 사용자에게 UI적으로 보여주지 않고도, 문제를 해결할 수 있을 것 같았다!

그래서 아래의 플로우를 따라 구현하였다.
<추가 예정!>

## 테스트 작성
테스트는 2가지를 작성해보았다.