### PR TITLE
[FIX/34] 로그인 시, 이전 로그인 정보가 남아있는 문제

### DIFF
--- a/app/src/main/java/com/w36495/senty/data/repository/GiftCategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/senty/data/repository/GiftCategoryRepositoryImpl.kt
@@ -1,14 +1,13 @@
 package com.w36495.senty.data.repository
 
 import android.util.Log
-import com.google.firebase.auth.FirebaseAuth
 import com.w36495.senty.data.domain.GiftCategoryEntity
 import com.w36495.senty.data.mapper.toDomain
 import com.w36495.senty.data.mapper.toEntity
 import com.w36495.senty.data.remote.service.GiftCategoryService
 import com.w36495.senty.domain.entity.GiftCategory
 import com.w36495.senty.domain.repository.GiftCategoryRepository
-import com.w36495.senty.domain.repository.GiftRepository
+import com.w36495.senty.domain.repository.UserRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,36 +18,36 @@ import kotlinx.serialization.json.jsonObject
 import javax.inject.Inject
 
 class GiftCategoryRepositoryImpl @Inject constructor(
-    private val firebaseAuth: FirebaseAuth,
-    private val giftCategoryService: GiftCategoryService
+    private val giftCategoryService: GiftCategoryService,
+    private val userRepository: UserRepository,
 ) : GiftCategoryRepository {
-    private var userId: String = firebaseAuth.currentUser!!.uid
-
     private val _categories = MutableStateFlow<List<GiftCategory>>(emptyList())
     override val categories: StateFlow<List<GiftCategory>>
         get() =_categories.asStateFlow()
 
     override suspend fun fetchCategories(): Result<Unit> {
         return try {
-            val result = giftCategoryService.fetchCategories(userId)
+            userRepository.runWithUid { userId ->
+                val result = giftCategoryService.fetchCategories(userId)
 
-            if (result.isSuccessful) {
-                val body = result.body()?.string()
+                if (result.isSuccessful) {
+                    val body = result.body()?.string()
 
-                if (body != null && result.headers()["Content-length"]?.toInt() != 4) {
-                    val responseJson = Json.parseToJsonElement(body)
+                    if (body != null && result.headers()["Content-length"]?.toInt() != 4) {
+                        val responseJson = Json.parseToJsonElement(body)
 
-                    val giftCategories = responseJson.jsonObject.map { (key, jsonElement) ->
-                        Json.decodeFromJsonElement<GiftCategoryEntity>(jsonElement).toDomain(key)
+                        val giftCategories = responseJson.jsonObject.map { (key, jsonElement) ->
+                            Json.decodeFromJsonElement<GiftCategoryEntity>(jsonElement).toDomain(key)
+                        }
+
+                        _categories.update { giftCategories.sortedBy { category -> category.name }.toList() }
+                        Result.success(Unit)
+                    } else {
+                        _categories.update { emptyList() }
+                        Result.success(Unit)
                     }
-
-                    _categories.update { giftCategories.sortedBy { category -> category.name }.toList() }
-                    Result.success(Unit)
-                } else {
-                    _categories.update { emptyList() }
-                    Result.success(Unit)
-                }
-            } else throw IllegalArgumentException(result.errorBody().toString())
+                } else Result.failure(IllegalArgumentException(result.errorBody().toString()))
+            }
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -67,11 +66,13 @@ class GiftCategoryRepositoryImpl @Inject constructor(
 
     override suspend fun insertCategory(category: GiftCategory): Result<Unit> {
         return try {
-            val response = giftCategoryService.insertCategory(userId, category.toEntity())
-            if (response.isSuccessful) {
-                fetchCategories()
-                Result.success(Unit)
-            } else Result.failure(Exception("선물 카테고리 등록 실패"))
+            userRepository.runWithUid { userId ->
+                val response = giftCategoryService.insertCategory(userId, category.toEntity())
+                if (response.isSuccessful) {
+                    fetchCategories()
+                    Result.success(Unit)
+                } else Result.failure(Exception("선물 카테고리 등록 실패"))
+            }
         } catch (e: Exception) {
             Log.d("GiftCategoryRepo", e.stackTraceToString())
             Result.failure(e)
@@ -80,12 +81,14 @@ class GiftCategoryRepositoryImpl @Inject constructor(
 
     override suspend fun updateCategory(category: GiftCategory): Result<Unit> {
         return try {
-            val response = giftCategoryService.patchCategory(userId, category.id, category.toEntity())
+            userRepository.runWithUid { userId ->
+                val response = giftCategoryService.patchCategory(userId, category.id, category.toEntity())
 
-            if (response.isSuccessful) {
-                fetchCategories()
-                Result.success(Unit)
-            } else Result.failure(Exception("선물 카테고리 수정 실패"))
+                if (response.isSuccessful) {
+                    fetchCategories()
+                    Result.success(Unit)
+                } else Result.failure(Exception("선물 카테고리 수정 실패"))
+            }
         } catch (e: Exception) {
             Log.d("GiftCategoryRepo", e.stackTraceToString())
             Result.failure(e)
@@ -94,14 +97,16 @@ class GiftCategoryRepositoryImpl @Inject constructor(
 
     override suspend fun deleteCategory(categoryId: String): Result<Unit> {
         return try {
-            val response = giftCategoryService.deleteCategory(userId, categoryId)
+            userRepository.runWithUid { userId ->
+                val response = giftCategoryService.deleteCategory(userId, categoryId)
 
-            if (response.isSuccessful) {
-                fetchCategories()
-                Result.success(Unit)
-            } else {
-                Log.d("GiftCategoryRepo", response.errorBody().toString())
-                Result.failure(Exception("선물 카테고리 삭제 실패 : ${response.errorBody().toString()}"))
+                if (response.isSuccessful) {
+                    fetchCategories()
+                    Result.success(Unit)
+                } else {
+                    Log.d("GiftCategoryRepo", response.errorBody().toString())
+                    Result.failure(Exception("선물 카테고리 삭제 실패 : ${response.errorBody().toString()}"))
+                }
             }
         } catch (e: Exception) {
             Log.d("GiftCategoryRepo", e.stackTraceToString())

--- a/app/src/main/java/com/w36495/senty/data/repository/GiftImageRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/senty/data/repository/GiftImageRepositoryImpl.kt
@@ -1,9 +1,9 @@
 package com.w36495.senty.data.repository
 
 import android.util.Log
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.storage.FirebaseStorage
 import com.w36495.senty.domain.repository.GiftImageRepository
+import com.w36495.senty.domain.repository.UserRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -67,6 +67,7 @@ class GiftImageRepositoryImpl @Inject constructor(
         image: ByteArray
     ): Result<Unit> {
         return suspendCancellableCoroutine { cont ->
+            val userId = userRepository.getUid()
             Log.d("GiftImage","🟢 ${if (imageName.contains("thumbs")) "썸네일" else "이미지"} 저장 시작" )
             val giftImagePath = "images/gifts/$userId/$giftId/$imageName.jpg"
 

--- a/app/src/main/java/com/w36495/senty/data/repository/GiftImageRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/senty/data/repository/GiftImageRepositoryImpl.kt
@@ -14,21 +14,21 @@ import kotlin.coroutines.resume
 
 class GiftImageRepositoryImpl @Inject constructor(
     private val firebaseStorage: FirebaseStorage,
-    private val firebaseAuth: FirebaseAuth,
+    private val userRepository: UserRepository,
 ) : GiftImageRepository {
-    private val userId: String
-        get() = firebaseAuth.currentUser?.uid ?: throw IllegalStateException("User not logged in")
 
     override suspend fun getGiftThumbs(giftId: String, imageName: String): Result<String> {
         return try {
-            Log.d("GiftImgRepo(getGiftThumbs)", "\n🎁 선물 썸네일 가져오는 중...")
-            val imgPath = "images/gifts/$userId/$giftId/${imageName.plus(".jpg")}"
+            userRepository.runWithUid { userId ->
+                Log.d("GiftImgRepo(getGiftThumbs)", "\n🎁 선물 썸네일 가져오는 중...")
+                val imgPath = "images/gifts/$userId/$giftId/${imageName.plus(".jpg")}"
 
-            val ref = firebaseStorage.reference.child(imgPath)
+                val ref = firebaseStorage.reference.child(imgPath)
 
-            val downloadUrl = ref.downloadUrl.await().toString()
-            Log.d("GiftImgRepo(getGiftThumbs)", "\uD83C\uDF81 선물 썸네일 다운로드 완료!")
-            Result.success(downloadUrl)
+                val downloadUrl = ref.downloadUrl.await().toString()
+                Log.d("GiftImgRepo(getGiftThumbs)", "\uD83C\uDF81 선물 썸네일 다운로드 완료!")
+                Result.success(downloadUrl)
+            }
         } catch (e: Exception) {
             Log.d("GiftImgRepo(getGiftThumbs)", e.stackTraceToString())
             Result.failure(e)
@@ -37,24 +37,26 @@ class GiftImageRepositoryImpl @Inject constructor(
 
     override suspend fun getGiftImages(giftId: String): Result<List<String>> {
         return try {
-            Log.d("GiftImgRepo(getGiftImages)", "\n🎁 선물 이미지 가져오는 중...")
-            val imgPath = "images/gifts/$userId/$giftId"
+            userRepository.runWithUid { userId ->
+                Log.d("GiftImgRepo(getGiftImages)", "\n🎁 선물 이미지 가져오는 중...")
+                val imgPath = "images/gifts/$userId/$giftId"
 
-            val imgResult = firebaseStorage.reference.child(imgPath).listAll().await()
-            val imagesWithoutThumbs = imgResult.items.filter { !it.name.contains("thumbs_") }
+                val imgResult = firebaseStorage.reference.child(imgPath).listAll().await()
+                val imagesWithoutThumbs = imgResult.items.filter { !it.name.contains("thumbs_") }
 
-            val itemCount = imgResult.items.size
-            Log.d("GiftImgRepo(getGiftImages)", "📸 다운로드할 이미지 개수: $itemCount")
+                val itemCount = imgResult.items.size
+                Log.d("GiftImgRepo(getGiftImages)", "📸 다운로드할 이미지 개수: $itemCount")
 
-            val downloadUrls = coroutineScope {
-                imagesWithoutThumbs
-                    .sortedBy { it.name }
-                    .map { ref ->
-                        async { ref.downloadUrl.await().toString() }
-                    }.awaitAll()
+                val downloadUrls = coroutineScope {
+                    imagesWithoutThumbs
+                        .sortedBy { it.name }
+                        .map { ref ->
+                            async { ref.downloadUrl.await().toString() }
+                        }.awaitAll()
+                }
+                Log.d("GiftImgRepo(getGiftImages)", "\uD83C\uDF81 선물 이미지 다운로드 완료!")
+                Result.success(downloadUrls.toList())
             }
-            Log.d("GiftImgRepo(getGiftImages)", "\uD83C\uDF81 선물 이미지 다운로드 완료!")
-            Result.success(downloadUrls.toList())
         } catch (e: Exception) {
             Log.d("GiftImgRepo(getGiftImages)", e.stackTraceToString())
             Result.failure(e)
@@ -90,12 +92,14 @@ class GiftImageRepositoryImpl @Inject constructor(
 
     override suspend fun deleteGiftImage(giftId: String, imgPath: String): Result<Unit> {
         return try {
-            Log.d("GiftImage","🟢 이미지 삭제 시작" )
-            val imagePath = "images/gifts/$userId/$giftId/$imgPath.jpg"
-            firebaseStorage.reference.child(imagePath).delete().await()
+            userRepository.runWithUid { userId ->
+                Log.d("GiftImage","🟢 이미지 삭제 시작" )
+                val imagePath = "images/gifts/$userId/$giftId/$imgPath.jpg"
+                firebaseStorage.reference.child(imagePath).delete().await()
 
-            Log.d("GiftImage","🟢 이미지 삭제 완료" )
-            Result.success(Unit)
+                Log.d("GiftImage","🟢 이미지 삭제 완료" )
+                Result.success(Unit)
+            }
         } catch (e: Exception) {
             Log.d("GiftImage","🔴 이미지 삭제 실패" )
             Log.d("GiftImageRepo(delete)", e.stackTraceToString())
@@ -105,25 +109,27 @@ class GiftImageRepositoryImpl @Inject constructor(
 
     override suspend fun deleteAllGiftImage(giftId: String): Result<Unit> {
         return try {
-            val path = "images/gifts/$userId/$giftId"
-            val giftDirRef = firebaseStorage.reference.child(path)
+            userRepository.runWithUid { userId ->
+                val path = "images/gifts/$userId/$giftId"
+                val giftDirRef = firebaseStorage.reference.child(path)
 
-            val allItems = giftDirRef.listAll().await() // 모든 이미지 참조 가져오기
+                val allItems = giftDirRef.listAll().await() // 모든 이미지 참조 가져오기
 
-            if (allItems.items.isEmpty()) {
-                Log.d("GiftImageRepo(deleteAll)", "삭제할 이미지가 존재하지 않음")
-                return Result.success(Unit)
-            }
-
-            coroutineScope {
-                allItems.items.map { itemRef ->
-                    async {
-                        itemRef.delete().await()
-                    }
+                if (allItems.items.isEmpty()) {
+                    Log.d("GiftImageRepo(deleteAll)", "삭제할 이미지가 존재하지 않음")
+                    Result.success(Unit)
                 }
-            }.awaitAll()
 
-            Result.success(Unit)
+                coroutineScope {
+                    allItems.items.map { itemRef ->
+                        async {
+                            itemRef.delete().await()
+                        }
+                    }
+                }.awaitAll()
+
+                Result.success(Unit)
+            }
         } catch (e: Exception) {
             Log.w("GiftImageRepo(deleteAll)", "전체 이미지 삭제 실패", e)
             Result.failure(e)

--- a/app/src/main/java/com/w36495/senty/data/repository/GiftRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/senty/data/repository/GiftRepositoryImpl.kt
@@ -1,13 +1,13 @@
 package com.w36495.senty.data.repository
 
 import android.util.Log
-import com.google.firebase.auth.FirebaseAuth
 import com.w36495.senty.data.domain.GiftEntity
 import com.w36495.senty.data.mapper.toDomain
 import com.w36495.senty.data.mapper.toEntity
 import com.w36495.senty.data.remote.service.GiftService
 import com.w36495.senty.domain.entity.Gift
 import com.w36495.senty.domain.repository.GiftRepository
+import com.w36495.senty.domain.repository.UserRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,10 +19,9 @@ import org.threeten.bp.LocalDate
 import javax.inject.Inject
 
 class GiftRepositoryImpl @Inject constructor(
-    private val firebaseAuth: FirebaseAuth,
     private val giftService: GiftService,
+    private val userRepository: UserRepository,
 ) : GiftRepository {
-    private var userId = firebaseAuth.currentUser!!.uid
     private val _gifts = MutableStateFlow<List<Gift>>(emptyList())
     override val gifts: StateFlow<List<Gift>>
         get() = _gifts.asStateFlow()
@@ -60,25 +59,30 @@ class GiftRepositoryImpl @Inject constructor(
 
     override suspend fun fetchGifts(): Result<Unit> {
         return try {
-            Log.d("GiftRepo","🟢 선물 조회 시작")
-            val response = giftService.fetchGifts(userId)
+            userRepository.runWithUid { userId ->
+                Log.d("GiftRepo","🟢 선물 조회 시작")
+                val response = giftService.fetchGifts(userId)
 
-            if (response.isSuccessful) {
-                val body = response.body()?.string()
-                if (body != null && response.headers()["Content-length"]?.toInt() != 4) {
-                    val responseJson = Json.parseToJsonElement(body)
+                if (response.isSuccessful) {
+                    val body = response.body()?.string()
+                    if (body != null && response.headers()["Content-length"]?.toInt() != 4) {
+                        val responseJson = Json.parseToJsonElement(body)
 
-                    val gifts = responseJson.jsonObject.map { (key, jsonElement) ->
-                        Json.decodeFromJsonElement<GiftEntity>(jsonElement).toDomain(key)
-                    }.toList().sortedByDescending { LocalDate.parse(it.date) }
+                        val gifts = responseJson.jsonObject.map { (key, jsonElement) ->
+                            Json.decodeFromJsonElement<GiftEntity>(jsonElement).toDomain(key)
+                        }.toList().sortedByDescending { LocalDate.parse(it.date) }
 
-                    Log.d("GiftRepo","🟢 선물 조회 완료")
-                    _gifts.update { gifts }
-                    Result.success(Unit)
-                } else Result.success(Unit)
-            } else {
-                Log.d("GiftRepo", response.errorBody()?.toString() ?: "errorBody is null")
-                Result.failure(Exception("오류가 발생했습니다."))
+                        Log.d("GiftRepo","🟢 선물 조회 완료")
+                        _gifts.update { gifts }
+                        Result.success(Unit)
+                    } else {
+                        _gifts.update { emptyList() }
+                        Result.success(Unit)
+                    }
+                } else {
+                    Log.d("GiftRepo", response.errorBody()?.toString() ?: "errorBody is null")
+                    Result.failure(Exception("오류가 발생했습니다."))
+                }
             }
         } catch (e: Exception) {
             Log.d("GiftRepo", e.stackTraceToString())
@@ -88,22 +92,24 @@ class GiftRepositoryImpl @Inject constructor(
 
     override suspend fun insertGift(gift: Gift): Result<String> {
         return try {
-            Log.d("GiftRepo","🟢 선물 등록 시작")
-            val response = giftService.insertGift(userId, gift.toEntity())
+            userRepository.runWithUid { userId ->
+                Log.d("GiftRepo","🟢 선물 등록 시작")
+                val response = giftService.insertGift(userId, gift.toEntity())
 
-            if (response.isSuccessful) {
-                val body = response.body()
+                if (response.isSuccessful) {
+                    val body = response.body()
 
-                if (body != null) {
-                    Log.d("GiftRepo","🟢 선물 등록 완료")
-                    Result.success(body.key)
+                    if (body != null) {
+                        Log.d("GiftRepo","🟢 선물 등록 완료")
+                        Result.success(body.key)
+                    } else {
+                        Log.d("GiftRepo","🔴 선물 등록 실패")
+                        Result.failure(Exception("선물 등록 실패"))
+                    }
                 } else {
                     Log.d("GiftRepo","🔴 선물 등록 실패")
                     Result.failure(Exception("선물 등록 실패"))
                 }
-            } else {
-                Log.d("GiftRepo","🔴 선물 등록 실패")
-                Result.failure(Exception("선물 등록 실패"))
             }
         } catch (e: Exception) {
             Log.d("GiftRepo","🔴 선물 등록 실패")
@@ -113,15 +119,17 @@ class GiftRepositoryImpl @Inject constructor(
 
     override suspend fun updateGift(gift: Gift): Result<Unit> {
         return try {
-            Log.d("GiftRepo","🟢 선물 수정 시작")
-            val response = giftService.patchGift(userId, gift.id, gift.copy(createdAt = gift.createdAt, updatedAt = System.currentTimeMillis()).toEntity())
+            userRepository.runWithUid { userId ->
+                Log.d("GiftRepo","🟢 선물 수정 시작")
+                val response = giftService.patchGift(userId, gift.id, gift.copy(createdAt = gift.createdAt, updatedAt = System.currentTimeMillis()).toEntity())
 
-            if (response.isSuccessful) {
-                Log.d("GiftRepo","🟢 선물 수정 완료")
-                Result.success(Unit)
-            } else {
-                Log.d("GiftRepo","🔴 선물 수정 실패")
-                Result.failure(Exception("선물 수정 실패"))
+                if (response.isSuccessful) {
+                    Log.d("GiftRepo","🟢 선물 수정 완료")
+                    Result.success(Unit)
+                } else {
+                    Log.d("GiftRepo","🔴 선물 수정 실패")
+                    Result.failure(Exception("선물 수정 실패"))
+                }
             }
         } catch (e: Exception) {
             Log.d("GiftRepo","🔴 선물 수정 실패")
@@ -131,20 +139,21 @@ class GiftRepositoryImpl @Inject constructor(
 
     override suspend fun deleteGift(giftId: String, refresh: Boolean): Result<Unit> {
         return try {
-            val response = giftService.deleteGift(userId, giftId)
+            userRepository.runWithUid { userId ->
+                val response = giftService.deleteGift(userId, giftId)
 
-            if (response.isSuccessful) {
-                if (refresh) fetchGifts()
-                Log.d("GiftRepo", "선물 삭제 성공")
-                Result.success(Unit)
-            } else {
-                Log.d("GiftRepo", "선물 삭제 실패 : ${response.errorBody()?.string()}")
-                Result.failure(Exception("선물 삭제 실패"))
+                if (response.isSuccessful) {
+                    if (refresh) fetchGifts()
+                    Log.d("GiftRepo", "선물 삭제 성공")
+                    Result.success(Unit)
+                } else {
+                    Log.d("GiftRepo", "선물 삭제 실패 : ${response.errorBody()?.string()}")
+                    Result.failure(Exception("선물 삭제 실패"))
+                }
             }
         } catch (e: Exception) {
             Log.d("GiftRepo", e.stackTraceToString())
             Result.failure(e)
         }
-
     }
 }

--- a/app/src/main/java/com/w36495/senty/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/senty/data/repository/UserRepositoryImpl.kt
@@ -5,6 +5,9 @@ import com.w36495.senty.domain.repository.UserRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
@@ -21,5 +24,14 @@ class UserRepositoryImpl @Inject constructor(
 
     override fun updateUser(user: AuthUser?) {
         _user.update { user }
+    }
+
+    override suspend fun <T> runWithUid(block: suspend (uid: String) -> Result<T>): Result<T> {
+        return user
+            .filterNotNull()
+            .map { it.uid }
+            .firstOrNull()
+            ?.let { uid -> block(uid) }
+            ?: Result.failure(IllegalStateException("로그인된 사용자가 없습니다."))
     }
 }

--- a/app/src/main/java/com/w36495/senty/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/w36495/senty/data/repository/UserRepositoryImpl.kt
@@ -15,6 +15,10 @@ class UserRepositoryImpl @Inject constructor(
     override val user: StateFlow<AuthUser?>
         get() = _user.asStateFlow()
 
+    override fun getUid(): String {
+        return _user.value?.uid ?: throw IllegalStateException("로그인된 사용자가 없습니다.")
+    }
+
     override fun updateUser(user: AuthUser?) {
         _user.update { user }
     }

--- a/app/src/main/java/com/w36495/senty/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/w36495/senty/domain/repository/UserRepository.kt
@@ -8,4 +8,6 @@ interface UserRepository {
 
     fun getUid(): String
     fun updateUser(user: AuthUser?)
+
+    suspend fun <T> runWithUid(block: suspend (uid: String) -> Result<T>): Result<T>
 }

--- a/app/src/main/java/com/w36495/senty/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/w36495/senty/domain/repository/UserRepository.kt
@@ -6,5 +6,6 @@ import kotlinx.coroutines.flow.StateFlow
 interface UserRepository {
     val user: StateFlow<AuthUser?>
 
+    fun getUid(): String
     fun updateUser(user: AuthUser?)
 }


### PR DESCRIPTION
## ISSUE
- #34 

## 문제 원인
### Repository 에서 사용되는 uid가 고정되어 있음
``` kotlin
class FriendGroupRepositoryImpl @Inject constructor(
    private val firebaseAuth: FirebaseAuth,
    private val friendGroupService: FriendGroupService,
) : FriendGroupRepository {
    private var userId: String = firebaseAuth.currentUser!!.uid

    ...
}
```
코드에서 보는 것 같이 userId 변수에 현재 로그인한 사용자의 uid 값 (firebaseAuth.currentUser!!.uid)을 할당해주었다.
그렇기에 처음 로그인한 사용자의 uid가 userId 변수에 담겨있는 상태에서 **로그아웃을 진행해도 새로 할당해주는 부분(update 부분)이 존재하지 않음을 디버깅을 통해 확인하였다.**
 
**디버깅을 통한 확인** 
![사진첨부1](https://github.com/user-attachments/assets/868ae6a2-1fa0-4ece-9c74-b0026d2e8e43)
위의 사진은 디버깅해보았을 때, 레포지토리의 userId와 현재 로그인한 사용자의 uid가 일치하지 않음을 확인한 부분이다.
 
## 해결
### UserRepository의 authUser를 통해 최신 uid 사용하기
``` kotlin
interface UserRepository {
    val user: StateFlow<AuthUser?>

    fun updateUser(user: AuthUser?)
```
현재 로그인한 사용자의 정보를 가지고 있는 UserRepsotiroy를 활용해야겠다고 생각했다.
로그인/로그아웃 시 최신 상태로 변경해주고 있기도 했고, StateFlow이니 상태를 관찰하여 최신 상태를 사용할 수 있었기 때문이다.

**그런데 StateFlow의 값을 어떻게 Repository에서 사용할 것인지?**
`.collectLatest()`를 통해 최신 값을 사용할 수 있다. 

그렇다면 모든 CRUD 함수들마다 collectLatest를 사용해야 하는데,그것이 최선일지? 같은 코드가 반복될 것이라 생각했고 UserRepository에서 user의 최신 상태를 반환해주면 좋을 것 같았다.
그래서 최신 uid를 반환해서 사용할 수 있는 고차함수를 작성하였다.
``` kotlin
// UserRepositoryImpl.kt

override suspend fun <T> runWithUid(block: suspend (uid: String) -> Result<T>): Result<T> {
    return user
        .filterNotNull()
        .map { it.uid }
        .firstOrNull()
        ?.let { uid -> block(uid) }
        ?: Result.failure(IllegalStateException("로그인된 사용자가 없습니다."))
    }
```

또 하나의 고민은 **모든 레포지토리가 UserRepository를 의존해야 하는데 괜찮은가?** 였다. 
데이터의 CRUD를 수행하려면 반드시 사용자의 uid가 필요하고 UserRepository에서 사용자 관련 책임을 가지고 있으니 의존해도 괜찮을 것 같다고 생각하였다!

## ScreenShot
|`Before`|`After`|
|:--:|:--:|
|![before](https://github.com/user-attachments/assets/94c53923-898b-4795-97fc-468fca3d2bd4)|![after](https://github.com/user-attachments/assets/5ee4292b-80a2-4888-a3fd-312b6751baf3)|