### PR TITLE
[FEAT] 등록/수정 시, 빠른 클릭으로 인한 동시성 이슈 방지

### DIFF
--- a/app/src/main/java/com/w36495/senty/domain/usecase/UpdateFriendGroupUseCase.kt
+++ b/app/src/main/java/com/w36495/senty/domain/usecase/UpdateFriendGroupUseCase.kt
@@ -3,15 +3,20 @@ package com.w36495.senty.domain.usecase
 import com.w36495.senty.domain.entity.FriendGroup
 import com.w36495.senty.domain.repository.FriendGroupRepository
 import com.w36495.senty.domain.repository.FriendRepository
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 
 class UpdateFriendGroupUseCase @Inject constructor(
     private val friendGroupRepository: FriendGroupRepository,
     private val friendRepository: FriendRepository,
 ) {
+    private val mutex = Mutex()
+
     suspend operator fun invoke(friendGroup: FriendGroup): Result<Unit> {
         return try {
-            friendGroupRepository.patchFriendGroup(friendGroup)
+            mutex
+                .withLock { friendGroupRepository.patchFriendGroup(friendGroup) }
                 .onSuccess {
                     friendRepository.getFriendsByFriendGroup(friendGroup.id)
                         .onSuccess {

--- a/app/src/main/java/com/w36495/senty/domain/usecase/UpdateGiftCategoryUseCase.kt
+++ b/app/src/main/java/com/w36495/senty/domain/usecase/UpdateGiftCategoryUseCase.kt
@@ -3,14 +3,19 @@ package com.w36495.senty.domain.usecase
 import com.w36495.senty.domain.entity.GiftCategory
 import com.w36495.senty.domain.repository.GiftCategoryRepository
 import com.w36495.senty.domain.repository.GiftRepository
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 
 class UpdateGiftCategoryUseCase @Inject constructor(
     private val giftCategoryRepository: GiftCategoryRepository,
     private val giftRepository: GiftRepository,
 ) {
+    private val mutex = Mutex()
+
     suspend operator fun invoke(category: GiftCategory): Result<Unit> {
-        return giftCategoryRepository.updateCategory(category)
+        return mutex
+            .withLock { giftCategoryRepository.updateCategory(category) }
             .onSuccess {
                 giftRepository.getGiftsByCategoryId(category.id)
                     .onSuccess {

--- a/app/src/main/java/com/w36495/senty/view/screen/friend/edit/EditFriendViewModel.kt
+++ b/app/src/main/java/com/w36495/senty/view/screen/friend/edit/EditFriendViewModel.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 
 @HiltViewModel
@@ -28,6 +30,8 @@ class EditFriendViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(EditFriendContact.State())
     val uiState = _uiState.asStateFlow()
+
+    private val mutex = Mutex()
 
     fun getFriend(friendId: String) {
         viewModelScope.launch {
@@ -96,8 +100,8 @@ class EditFriendViewModel @Inject constructor(
         viewModelScope.launch {
             updateLoadingState(true)
 
-            val result = friendRepository.insertFriend(friend.toDomain())
-            
+            val result = mutex.withLock { friendRepository.insertFriend(friend.toDomain()) }
+
             result
                 .onSuccess {
                     updateLoadingState(false)
@@ -116,7 +120,7 @@ class EditFriendViewModel @Inject constructor(
         viewModelScope.launch {
             updateLoadingState(true)
 
-            val result = updateFriendUseCase(friend.toDomain())
+            val result = mutex.withLock { updateFriendUseCase(friend.toDomain()) }
 
             result
                 .onSuccess {

--- a/app/src/main/java/com/w36495/senty/view/screen/friendgroup/EditFriendGroupViewModel.kt
+++ b/app/src/main/java/com/w36495/senty/view/screen/friendgroup/EditFriendGroupViewModel.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,6 +29,8 @@ class EditFriendGroupViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow<EditFriendGroupContact.State>(EditFriendGroupContact.State.Idle)
     val uiState get() = _uiState.asStateFlow()
+
+    private val mutex = Mutex()
 
     fun handleEvent(event: EditFriendGroupContact.Event) {
         when (event) {
@@ -43,7 +47,7 @@ class EditFriendGroupViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { EditFriendGroupContact.State.Loading }
 
-            val result = friendGroupRepository.insertFriendGroup(newFriendGroup.toDomain())
+            val result = mutex.withLock { friendGroupRepository.insertFriendGroup(newFriendGroup.toDomain()) }
 
             result
                 .onSuccess { _ ->

--- a/app/src/main/java/com/w36495/senty/view/screen/gift/category/GiftCategoriesViewModel.kt
+++ b/app/src/main/java/com/w36495/senty/view/screen/gift/category/GiftCategoriesViewModel.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 
 @HiltViewModel
@@ -28,6 +30,8 @@ class GiftCategoriesViewModel @Inject constructor(
     private val deleteGiftCategoryUseCase: DeleteGiftCategoryUseCase,
     private val updateGiftCategoryUseCase: UpdateGiftCategoryUseCase,
 ) : ViewModel() {
+    private val mutex = Mutex()
+
     private val _effect = Channel<GiftCategoryContact.Effect>()
     val effect = _effect.receiveAsFlow()
 
@@ -150,7 +154,7 @@ class GiftCategoriesViewModel @Inject constructor(
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true) }
 
-            val result = giftCategoryRepository.insertCategory(category.toDomain())
+            val result = mutex.withLock { giftCategoryRepository.insertCategory(category.toDomain()) }
 
             result
                 .onSuccess {


### PR DESCRIPTION
## ISSUE
- 데이터 등록/수정 시, 버튼을 빠르게 클릭하면 데이터가 연속으로 저장됨
- UI 적으로는 버튼에 ProgressBar를 적용하였지만 그럼에도 2번의 네트워크 통신 작업이 이루어짐을 확인

![스크린샷 2025-05-07 19 08 33](https://github.com/user-attachments/assets/0459cb35-c6d2-4c19-9fbc-34e21eba0ab1)

## Todo
- [x] 등록/수정이 발생하는 ViewModel/UseCase에 Mutex를 이용하여 동기화 적용 

## ScreenShot
|`Before`|`After`|
|:--:|:--:|
|![before](https://github.com/user-attachments/assets/be6cb995-7569-4e8e-9e86-37bb1f16d8a7)|![after](https://github.com/user-attachments/assets/1c07cc7b-b01b-46b9-bde3-af1518c6ce4d)|
|데이터가 2개 저장됨을 확인|Mutex 적용 후, 데이터가 1개 저장됨을 확인|


